### PR TITLE
Fix-issue#8

### DIFF
--- a/ncigrafana/UsageDataset.py
+++ b/ncigrafana/UsageDataset.py
@@ -664,4 +664,4 @@ class ProjectDataset(object):
                     date=date.date(),
                     members=members_csv,
                     members_count=members_count)
-        return self.db['ProjectMembership'].upsert(data, ['project_id', 'system_id', 'date', 'members', 'members_list'])
+        return self.db['ProjectMembership'].upsert(data, ['project_id', 'system_id', 'date'])

--- a/test/2024-12-03T11:09:28.au88.membership.upsert.dump
+++ b/test/2024-12-03T11:09:28.au88.membership.upsert.dump
@@ -1,0 +1,3 @@
+%%%%%%%%%%%%%%%%
+Tue Dec 03 11:09:29 AEDT 2024
+au88:*:8950:test502,test581,test561,blah_ci,test654

--- a/test/test_parse_membership.py
+++ b/test/test_parse_membership.py
@@ -40,3 +40,22 @@ def test_parse_membership(db):
     
     membership_record = db.db["ProjectMembership"].find_one(project_id=project_id, date=datetime.date(2024,12,3))
     assert len(membership_record["members"].split(",")) == 3
+
+
+def test_parse_membership_upsert_funcationality(db):
+
+    parse_membership('test/2024-12-03T11:09:28.au88.membership.dump', verbose=verbose, db=db)
+
+    assert db.db["Users"].count() == 3
+    assert db.db["Users"].find_one(user='test581')
+    assert db.db["Projects"].find_one(project='au88')
+
+    project_id = db.db["Projects"].find_one(project='au88')['id']
+    assert db.db["ProjectMembership"].find_one(project_id=project_id, date=datetime.date(2024,12,3))
+    
+    membership_record = db.db["ProjectMembership"].find_one(project_id=project_id, date=datetime.date(2024,12,3))
+    assert len(membership_record["members"].split(",")) == 3
+
+    parse_membership('test/2024-12-03T11:09:28.au88.membership.upsert.dump', verbose=verbose, db=db)
+    membership_record = db.db["ProjectMembership"].find_one(project_id=project_id, date=datetime.date(2024,12,3))
+    assert len(membership_record["members"].split(",")) == 4

--- a/test/test_parse_membership.py
+++ b/test/test_parse_membership.py
@@ -42,7 +42,7 @@ def test_parse_membership(db):
     assert len(membership_record["members"].split(",")) == 3
 
 
-def test_parse_membership_upsert_funcationality(db):
+def test_parse_membership_upsert_functionality(db):
 
     parse_membership('test/2024-12-03T11:09:28.au88.membership.dump', verbose=verbose, db=db)
 


### PR DESCRIPTION
Fix #8

https://github.com/ACCESS-NRI/ncigrafana/issues/8

Upsert was failing for parse upload, on reading the docs it seems we have too many fields defined in the `keys` kwarg.

https://dataset.readthedocs.io/en/latest/api.html#dataset.Table.upsert

