### PR TITLE
Update CD with our version of action-build-and-upload-conda-packages

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -35,5 +35,4 @@ jobs:
         with:
           meta_yaml_dir: conda
           user: accessnri
-          label: main
           token: ${{ secrets.anaconda_token }}

--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@v4
         with:
             fetch-tags: true
-            fetch-depth: 0 
+            fetch-depth: 0
 
       - name: Setup conda environment
         uses: conda-incubator/setup-miniconda@d2e6a045a86077fb6cad6f5adf368e9076ddaa8d # v3.1.0
@@ -31,10 +31,9 @@ jobs:
           show-channel-urls: true
 
       - name: Build and upload the conda package
-        uses: uibcdf/action-build-and-upload-conda-packages@d72a2d950af55243bbc385185dd68b824211192d #v1.3.0
+        uses: ACCESS-NRI/action-build-and-upload-conda-packages@3ba32e822e374fb238fa9b1c67107fd2791c2ae2 #v2.0.0
         with:
           meta_yaml_dir: conda
-          python-version: ${{ env.PY_VERSION }}
           user: accessnri
           label: main
           token: ${{ secrets.anaconda_token }}


### PR DESCRIPTION
Updates to CD to use our version of action-build-and-upload-conda-packages, which should fix issue with pushing packages to annaconda. 