### PR TITLE
Try updating any missing user information

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -2,8 +2,8 @@ name: CD
 
 on:
   push:
-    branches:
-        - master
+    tags:
+      - '*'
 
 env:
   PY_VERSION: 3.12
@@ -15,13 +15,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
             fetch-tags: true
             fetch-depth: 0
 
       - name: Setup conda environment
-        uses: conda-incubator/setup-miniconda@d2e6a045a86077fb6cad6f5adf368e9076ddaa8d # v3.1.0
+        uses: conda-incubator/setup-miniconda@fc2d68f6413eb2d87b895e92f8584b5b94a10167 # v3.3.0
         with:
           miniconda-version: "latest"
           python-version: ${{ env.PY_VERSION }}
@@ -31,7 +31,7 @@ jobs:
           show-channel-urls: true
 
       - name: Build and upload the conda package
-        uses: ACCESS-NRI/action-build-and-upload-conda-packages@3ba32e822e374fb238fa9b1c67107fd2791c2ae2 #v2.0.0
+        uses: ACCESS-NRI/action-build-and-upload-conda-packages@d97711bc4445ba5c4de55f5a1bccbd4815286289 #v3.0.0
         with:
           meta_yaml_dir: conda
           user: accessnri

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -2,24 +2,60 @@ name: CI Testing
 
 on:
   push:
+    branches: [ master ]
   pull_request:
+    branches: [ master ]
+
+  workflow_dispatch:
+
+env:
+  PY_VERSION: 3.12
 
 jobs:
+  conda-build:
+    name: Conda Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-tags: true
+          fetch-depth: 0
+
+      - name: Setup conda environment
+        uses: conda-incubator/setup-miniconda@fc2d68f6413eb2d87b895e92f8584b5b94a10167 # v3.3.0
+        with:
+          miniconda-version: "latest"
+          python-version: ${{ env.PY_VERSION }}
+          environment-file: conda/environment.yml
+          auto-update-conda: false
+          auto-activate-base: false
+          show-channel-urls: true
+
+      - name: Build conda package
+        uses: ACCESS-NRI/action-build-and-upload-conda-packages@d97711bc4445ba5c4de55f5a1bccbd4815286289 #v3.0.0
+        with:
+          meta_yaml_dir: conda
+          upload: false
+
   testing:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8, 3.9]
+        python-version: ["3.10", "3.11", "3.12"]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
+
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
+          cache: "pip"
+
       - name: Install dependencies
         run: |
           python -m pip install '.[build]'
+
       - name: Run tests
         run: |
           python -m pytest test

--- a/ncigrafana/UsageDataset.py
+++ b/ncigrafana/UsageDataset.py
@@ -60,6 +60,18 @@ class ProjectDataset(object):
                     gid = -1
             data = dict(user=user, uid=uid, gid=gid, fullname=fullname)
             id = self.db['Users'].upsert(data, list(data.keys()))
+        elif q['uid'] == -1 or q['gid'] == -1:
+            id = q['id']
+            # Try update user information if it was missing
+            try:
+                passwd = getpwnam(user)
+                fullname = passwd.pw_gecos
+                uid = passwd.pw_uid
+                gid = passwd.pw_gid
+                data = dict(id=id, user=user, uid=uid, gid=gid, fullname=fullname)
+                self.db['Users'].upsert(data, ['id', 'user'])
+            except KeyError:
+                pass
         else:
             id = q['id']
         return id

--- a/test/test_UsageDataset.py
+++ b/test/test_UsageDataset.py
@@ -5,6 +5,7 @@ from __future__ import print_function
 import pytest
 import sys
 import pandas as pd
+from unittest.mock import patch, Mock
 
 from numpy.testing import assert_array_equal, assert_array_almost_equal
 from numpy import arange
@@ -53,6 +54,53 @@ def test_adduser(db):
     record = db.getuser(user)
     assert( record['user'] == user )
     assert( record['fullname'] == user )
+
+
+def test_adduser_update_missing_data(db):
+    # Add a user to the database
+    user = "abc123"
+    db.adduser(user)
+    record = db.getuser(user)
+    assert record.get('user') == user
+    assert record.get('fullname') == user
+    assert record.get('uid') == -1
+    assert record.get('gid') == -1
+    previous_id = record['id']
+
+    # Try adding same user again - expect no change with KeyError
+    id = db.adduser(user)
+    assert id == previous_id
+    record = db.getuser(user)
+    assert record.get('id') == previous_id
+    assert record.get('user') == user
+    assert record.get('fullname') == user
+    assert record.get('uid') == -1
+    assert record.get('gid') == -1
+
+    # Patch getpwnam to return user information and check missing information is updated
+    with patch('ncigrafana.UsageDataset.getpwnam') as mock_getpwnam:
+        mock_struct_passwd = Mock()
+        mock_struct_passwd.pw_gecos = 'Abc Xyz'
+        mock_struct_passwd.pw_uid = 1001
+        mock_struct_passwd.pw_gid = 101
+        mock_getpwnam.return_value = mock_struct_passwd
+
+        id = db.adduser(user)
+        assert id == previous_id
+
+        record = db.getuser(user)
+        assert record.get('id') == previous_id
+        assert record.get('user') == user
+        assert record.get('fullname') == 'Abc Xyz'
+        assert record.get('uid') == 1001
+        assert record.get('gid') == 101
+
+        # Check adduser does not call getpwnam again when there's no missing information
+        mock_getpwnam.reset_mock()
+        id = db.adduser(user)
+        assert id == previous_id
+        mock_getpwnam.assert_not_called()
+
 
 def test_addquarter(db):
     year = 1984; month = 7; day = 1 


### PR DESCRIPTION
This PR adds a minimal change to update `fullname`, `gid`, `uid` when `uid` or `gid` is -1. -1 is set as the fallback when there's values aren't available. 

This will hopefully update the 51 users which have fullname `On host`, uid `1` and gid `-1` in the database.

Related to https://github.com/ACCESS-NRI/dumpstats/issues/70