### PR TITLE
Fix User row update creating an index

### DIFF
--- a/ncigrafana/UsageDataset.py
+++ b/ncigrafana/UsageDataset.py
@@ -69,7 +69,7 @@ class ProjectDataset(object):
                 uid = passwd.pw_uid
                 gid = passwd.pw_gid
                 data = dict(id=id, user=user, uid=uid, gid=gid, fullname=fullname)
-                self.db['Users'].upsert(data, ['id', 'user'])
+                self.db['Users'].update(data, ['id'])
             except KeyError:
                 pass
         else:


### PR DESCRIPTION
This is fixing a change added in #14. This is raising an error in the [dumpstats workflow run](https://github.com/ACCESS-NRI/dumpstats/actions/runs/24641910496/job/72047294251#step:3:306):

```
sqlalchemy.exc.ProgrammingError: (psycopg2.errors.InsufficientPrivilege) must be owner of table Users

[SQL: CREATE INDEX "ix_Users_bf75528948e7bc04" ON "Users" (id, "user")]
```

I didn't realise using upsert with `['id', 'user']` would attempt to create an index. I've change `['id', 'user']` -> `['id']` as the primary key is an index, and actually should be sufficient information to update the row. I've changed `upsert` to `update` too as it won't ever be inserting a row in the table at that point. 

